### PR TITLE
Fixed Flaky Test in AnnotatedMessageHandlingMemberTest.java

### DIFF
--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
@@ -24,6 +24,8 @@ import org.axonframework.messaging.HandlerAttributes;
 import org.junit.jupiter.api.*;
 
 import java.util.Optional;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,8 +40,9 @@ class AnnotatedMessageHandlingMemberTest {
 
     @BeforeEach
     void setUp() {
+        Method method = Arrays.asList(AnnotatedHandler.class.getMethods()).stream().filter(m->"handlingMethod".equals(m.getName())).findFirst().orElse(null);
         testSubject = new AnnotatedMessageHandlingMember<>(
-                AnnotatedHandler.class.getMethods()[0],
+                method,
                 EventMessage.class,
                 String.class,
                 ClasspathParameterResolverFactory.forClass(AnnotatedHandler.class)


### PR DESCRIPTION
The test `attributeReturnsNonEmptyOptionalForMatchingAttributeKey` is deemed to be flaky as sometimes the test fails to have the message attribute, based on the result of the `getMethods()` function used in the testsubject initialization during setup.

This is due to the initialization hashmap of the class returning methods in non-deterministic order causing the wrong method to be assigned when picking the first method using `AnnotatedHandler.class.getMethods()[0]`.

I changed the assignment for the method during initialization in the test setup, using a stream and filter to make sure that the `handlingMethod` is always rightly assigned removing the flaky behavior of the test and making sure a nonempty optional is returned for the matching attribute.